### PR TITLE
Fix seconds formatting depending on value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,8 @@
 //! The library comes with one struct implementation of this trait, [`Czas`], which supports localization in Polish.
 pub use crate::errors::CzasError;
 pub use crate::mapping::polish::{
-    date_to_polish_genitive, hours_to_polish_locative, month_to_polish_genitive,
-    seconds_or_minutes_to_polish_nominative, year_to_polish_genetive,
+    date_to_polish_genitive, hours_to_polish_locative, minutes_to_polish_nominative,
+    month_to_polish_genitive, seconds_to_polish_nominative, year_to_polish_genetive,
 };
 use chrono::{Datelike, NaiveDateTime, Timelike};
 
@@ -44,8 +44,8 @@ impl ToLocalizedText for Czas {
     ///
     /// Will return a [`CzasError`] if the timestamp is invalid   
     fn from_naive_date_time(timestamp: NaiveDateTime) -> Result<String, CzasError> {
-        let second = seconds_or_minutes_to_polish_nominative(timestamp.second())?;
-        let minute = seconds_or_minutes_to_polish_nominative(timestamp.minute())?;
+        let second = seconds_to_polish_nominative(timestamp.second())?;
+        let minute = minutes_to_polish_nominative(timestamp.minute())?;
         let hour = hours_to_polish_locative(timestamp.hour())?;
         let day = date_to_polish_genitive(timestamp.day())?;
         let month = month_to_polish_genitive(timestamp.month())?;
@@ -56,7 +56,7 @@ impl ToLocalizedText for Czas {
             base_string = format!("{base_string} {minute}");
         };
         if !second.is_empty() {
-            base_string = format!("{base_string} i {second} sekundy");
+            base_string = format!("{base_string} i {second}");
         }
         Ok(base_string)
     }
@@ -92,7 +92,7 @@ mod tests {
 
         assert_eq!(
             result,
-            String::from("dziesiątego listopada dwa tysiące dwudziestego trzeciego roku o dziewiętnastej pięć i czterdzieści sześć sekundy")
+            String::from("dziesiątego listopada dwa tysiące dwudziestego trzeciego roku o dziewiętnastej pięć i czterdzieści sześć sekund")
         );
     }
 
@@ -102,7 +102,7 @@ mod tests {
 
         assert_eq!(
             result,
-            String::from("pierwszego stycznia dwa tysiące dwudziestego roku o pierwszej dwadzieścia trzy i czterdzieści pięć sekundy")
+            String::from("pierwszego stycznia dwa tysiące dwudziestego roku o pierwszej dwadzieścia trzy i czterdzieści pięć sekund")
         );
     }
 
@@ -113,7 +113,7 @@ mod tests {
         assert_eq!(
             result,
             String::from(
-                "pierwszego stycznia dwa tysiące dwudziestego roku o pierwszej i jeden sekundy"
+                "pierwszego stycznia dwa tysiące dwudziestego roku o pierwszej i jeden sekunda"
             )
         );
     }

--- a/src/mapping/polish.rs
+++ b/src/mapping/polish.rs
@@ -1,21 +1,91 @@
 use crate::errors::CzasError;
 
-/// Converts a second or minute value to the Polish Nominative/Mianownik form
+/// Converts a second value to the Polish Nominative/Mianownik form
 ///
 /// # Examples
 ///
 /// ```rust
-/// let second = czas::seconds_or_minutes_to_polish_nominative(1).unwrap();
-/// assert_eq!(second, "jeden");
+/// let second = czas::seconds_to_polish_nominative(1).unwrap();
+/// assert_eq!(second, "jeden sekunda");
+/// ```
+///
+/// ```rust
+/// let second = czas::seconds_to_polish_nominative(3).unwrap();
+/// assert_eq!(second, "trzy sekundy");
 /// ```
 ///
 /// # Errors
 ///
-/// Will return a [`CzasError`] if !(0 <= `seconds_or_minutes` <= 59)
-pub fn seconds_or_minutes_to_polish_nominative(
-    seconds_or_minutes: u32,
-) -> Result<String, CzasError> {
-    match seconds_or_minutes % 60 {
+/// Will return a [`CzasError`] if !(0 <= `seconds` <= 59)
+pub fn seconds_to_polish_nominative(seconds: u32) -> Result<String, CzasError> {
+    match seconds % 60 {
+        0 => Ok(String::new()),
+        1 => Ok("jeden sekunda".to_string()),
+        2 => Ok("dwa sekundy".to_string()),
+        3 => Ok("trzy sekundy".to_string()),
+        4 => Ok("cztery sekundy".to_string()),
+        5 => Ok("pięć sekund".to_string()),
+        6 => Ok("sześć sekund".to_string()),
+        7 => Ok("siedem sekund".to_string()),
+        8 => Ok("osiem sekund".to_string()),
+        9 => Ok("dziewięć sekund".to_string()),
+        10 => Ok("dziesięć sekund".to_string()),
+        11 => Ok("jedenaście sekund".to_string()),
+        12 => Ok("dwanaście sekund".to_string()),
+        13 => Ok("trzynaście sekund".to_string()),
+        14 => Ok("czternaście sekund".to_string()),
+        15 => Ok("piętnaście sekund".to_string()),
+        16 => Ok("szesnaście sekund".to_string()),
+        17 => Ok("siedemnaście sekund".to_string()),
+        18 => Ok("osiemnaście sekund".to_string()),
+        19 => Ok("dziewiętnaście sekund".to_string()),
+        20 => Ok("dwadzieścia sekund".to_string()),
+        21 => Ok("dwadzieścia jeden sekund".to_string()),
+        22..=29 => Ok(format!(
+            "dwadzieścia {}",
+            seconds_to_polish_nominative(seconds - 20)?
+        )),
+        30 => Ok("trzydzieści sekund".to_string()),
+        31 => Ok("trzydzieści jeden sekund".to_string()),
+        32..=39 => Ok(format!(
+            "trzydzieści {}",
+            seconds_to_polish_nominative(seconds - 30)?
+        )),
+        40 => Ok("czterdzieści sekund".to_string()),
+        41 => Ok("czterdzieści jeden sekund".to_string()),
+        42..=49 => Ok(format!(
+            "czterdzieści {}",
+            seconds_to_polish_nominative(seconds - 40)?
+        )),
+        50 => Ok("pięćdziesiąt sekund".to_string()),
+        51 => Ok("pięćdziesiąt jeden sekund".to_string()),
+        52..=59 => Ok(format!(
+            "pięćdziesiąt {}",
+            seconds_to_polish_nominative(seconds - 50)?
+        )),
+        _ => Err(CzasError::Error),
+    }
+}
+
+/// Converts a minute value to the Polish Nominative/Mianownik form
+///
+/// # Examples
+///
+/// ```rust
+/// let minute = czas::minutes_to_polish_nominative(1).unwrap();
+/// assert_eq!(minute, "jeden");
+/// ```
+///
+/// ```rust
+/// let minute = czas::minutes_to_polish_nominative(19).unwrap();
+/// assert_eq!(minute, "dziewiętnaście");
+/// ```
+///
+/// # Errors
+///
+/// Will return a [`CzasError`] if !(0 <= `minute` <= 59)
+pub fn minutes_to_polish_nominative(minutes: u32) -> Result<String, CzasError> {
+    match minutes % 60 {
         0 => Ok(String::new()),
         1 => Ok("jeden".to_string()),
         2 => Ok("dwa".to_string()),
@@ -39,22 +109,22 @@ pub fn seconds_or_minutes_to_polish_nominative(
         20 => Ok("dwadzieścia".to_string()),
         21..=29 => Ok(format!(
             "dwadzieścia {}",
-            seconds_or_minutes_to_polish_nominative(seconds_or_minutes - 20)?
+            minutes_to_polish_nominative(minutes - 20)?
         )),
         30 => Ok("trzydzieści".to_string()),
         31..=39 => Ok(format!(
             "trzydzieści {}",
-            seconds_or_minutes_to_polish_nominative(seconds_or_minutes - 30)?
+            minutes_to_polish_nominative(minutes - 30)?
         )),
         40 => Ok("czterdzieści".to_string()),
         41..=49 => Ok(format!(
             "czterdzieści {}",
-            seconds_or_minutes_to_polish_nominative(seconds_or_minutes - 40)?
+            minutes_to_polish_nominative(minutes - 40)?
         )),
         50 => Ok("pięćdziesiąt".to_string()),
-        51..=59 => Ok(format!(
+        52..=59 => Ok(format!(
             "pięćdziesiąt {}",
-            seconds_or_minutes_to_polish_nominative(seconds_or_minutes - 50)?
+            minutes_to_polish_nominative(minutes - 50)?
         )),
         _ => Err(CzasError::Error),
     }


### PR DESCRIPTION
This PR fixes the formatting of seconds to their proper values ("sekunda"/"sekundy"/"sekund") depending on the value